### PR TITLE
consistent insertion of 'Abstract:' heading in Word: https://github.c…

### DIFF
--- a/lib/isodoc/ieee/word_authority.rb
+++ b/lib/isodoc/ieee/word_authority.rb
@@ -138,8 +138,8 @@ module IsoDoc
       end
 
       def feedback_style(docxml)
-        docxml.at("//div[@class = 'boilerplate-feedback']")&.xpath("./div")
-          &.each_with_index do |div, i|
+        f = docxml.at("//div[@class = 'boilerplate-feedback']") or return
+        f.xpath("./div").each_with_index do |div, i|
           i.zero? or div.elements.first.previous = "<p>&#xa0;</p>"
           i == 4 and
             div.xpath(".//p[br]").each do |p|
@@ -182,6 +182,7 @@ module IsoDoc
         if f = docxml.at("//div[@class = 'abstract']")
           f.previous_element.remove
           abstract_cleanup1(f, dest)
+          abstract_header(dest)
           f.remove
         elsif f = docxml.at("//div[@type = 'scope']")
           abstract_cleanup1(f, dest)

--- a/spec/isodoc/postproc_spec.rb
+++ b/spec/isodoc/postproc_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe IsoDoc::IEEE do
           <div class='main-section'>
             <hr/>
             <div id='abstract-destination'>
-               <p class='IEEEStdsAbstractBody' style="font-family: 'Arial', sans-serif;">Abstract text</p>
+               <p class='IEEEStdsAbstractBody' style="font-family: 'Arial', sans-serif;"><span class="IEEEStdsAbstractHeader"><span lang="EN-US">Abstract:</span></span> Abstract text</p>
                <ul>
                  <li>
                    <p style="font-family: 'Arial', sans-serif;" class='IEEEStdsAbstractBody'>X</p>

--- a/spec/isodoc/word_spec.rb
+++ b/spec/isodoc/word_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe IsoDoc::IEEE::WordConvert do
     output = <<~OUTPUT
       <div>
         <a name='abstract-destination' id='abstract-destination'/>
-        <div class='IEEEStdsWarning'>This introduction is not part of P1000/D0.3.4, Draft Standard for Empty </div>
+        <div class='IEEEStdsWarning'><span class="IEEEStdsAbstractHeader"><span lang="EN-US" xml:lang="EN-US">Abstract:</span></span> This introduction is not part of P1000/D0.3.4, Draft Standard for Empty </div>
         <p class='IEEEStdsAbstractBody' style="font-family: 'Arial', sans-serif;">Text</p>
         <div class="ul_wrap">
         <p style="mso-list:l11 level1 lfo1-1;text-indent:-0.79cm; margin-left:1.1600000000000001cm;font-family: 'Arial', sans-serif;" class="IEEEStdsUnorderedListCxSpFirst">List</p>


### PR DESCRIPTION
…om/metanorma/metanorma-ieee/issues/379

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
