### PR TITLE
Migrate to relaton-render 1.3.0: split at:/in: i18n keys

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,2 @@
+gem "relaton-render", git: "https://github.com/relaton/relaton-render", branch: "fix/at-in-i18n-disambiguation"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"

--- a/lib/isodoc/ieee/word_cleanup_blocks.rb
+++ b/lib/isodoc/ieee/word_cleanup_blocks.rb
@@ -105,7 +105,7 @@ module IsoDoc
       def note_style_cleanup(docxml)
         docxml.xpath("//span[@class = 'note_label']").each do |s|
           multi = /^#{@i18n.note}\s+[A-Z0-9.]+/.match?(s.text)
-          div = s.at("./ancestor::div[@class = 'Note']")
+          div = s.at("./ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' Note ')]")
           if multi
             s.remove
             seq = notesequence(div)

--- a/lib/metanorma/ieee/isodoc.rng
+++ b/lib/metanorma/ieee/isodoc.rng
@@ -213,6 +213,12 @@ Sources are currently only rendered in metanorma-plateau</a:documentation>
     <define name="ExampleAttributes">
       <ref name="NumberingAttributes"/>
       <ref name="BlockAttributes"/>
+      <optional>
+        <attribute name="collapsible">
+          <a:documentation>Render the example as collapsible (HTML5 details/summary)</a:documentation>
+          <data type="boolean"/>
+        </attribute>
+      </optional>
     </define>
     <define name="ExampleBody">
       <optional>

--- a/lib/relaton/render/config.yml
+++ b/lib/relaton/render/config.yml
@@ -24,7 +24,7 @@ template:
   manual: book
   proceedings: book
   inproceedings: "{{ creatornames }}$$$ “{{ title }}$$$|” <em>{{host_title}}</em>$$$ {{place}}$$$ {{extent}}$$$ {{disambiguated_date}}$$$ {{ labels['viewed'] }}_{{date_accessed}}$$$ {% if uri %}{{ uri }}{% else %}{% if doi %}DOI: {{ doi | join: '$$$ ' }}{% endif %}{% endif %} $$$"
-  inbook: "{{ creatornames }}$$$ “{{ title }}$$$|” {{ labels['in'] }} {{ host_creatornames}} ({{ host_role}}) : <em>{{host_title}}</em>$$$ {{place}}: {{publisher}}$$$ {{disambiguated_date}}$$$ {{extent}}$$$ {{ labels['viewed'] }}_{{date_accessed}}$$$ {% if uri %}{{ uri }}{% else %}{% if doi %}DOI: {{ doi | join: '$$$ ' }}{% endif %}{% endif %} $$$"
+  inbook: "{{ creatornames }}$$$ “{{ title }}$$$|” {{ labels['in_document'] }} {{ host_creatornames}} ({{ host_role}}) : <em>{{host_title}}</em>$$$ {{place}}: {{publisher}}$$$ {{disambiguated_date}}$$$ {{extent}}$$$ {{ labels['viewed'] }}_{{date_accessed}}$$$ {% if uri %}{{ uri }}{% else %}{% if doi %}DOI: {{ doi | join: '$$$ ' }}{% endif %}{% endif %} $$$"
   incollection: inbook
   thesis: "{{ creatornames }} $$$ “{{ title }}$$$|” {{ medium | capitalize }}$$$ {{ publisher }}$$$ {{ disambiguated_date }}$$$ {{ labels['viewed'] }}_{{date_accessed}}$$$ {% if uri %}{{ uri }}{% else %}{% if doi %}DOI: {{ doi | join: '$$$ ' }}{% endif %}{% endif %} $$$"
   unpublished: thesis

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe Metanorma::Ieee do
                <docidentifier type="ISO" primary="true">ISO 639:2023</docidentifier>
                <docidentifier type="metanorma-ordinal">[B2]</docidentifier>
                <docidentifier type="iso-reference">ISO 639:2023(E)</docidentifier>
-               <docidentifier type="URN">urn:iso:std:iso:639:stage-60.60</docidentifier>
+               <docidentifier type="URN">urn:iso:std:iso:639</docidentifier>
                <docnumber>639</docnumber>
                <date type="published">
                  <on>2023-11-08</on>
@@ -945,7 +945,7 @@ RSpec.describe Metanorma::Ieee do
            <bibitem id="_" type="standard" anchor="ref21">
              <docidentifier type="ISO" primary="true">ISO/IEC 2382</docidentifier>
              <docidentifier type="iso-reference">ISO/IEC 2382(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso-iec:2382:stage-90.60</docidentifier>
+             <docidentifier type="URN">urn:iso:std:iso-iec:2382:stage-90.92</docidentifier>
              <note type="Availability">
                 <p id="_">ISO/IEC documents are available from the International Organization for Standardization (https://www.iso.org/). ISO/IEC publications are also available in the United States from Global Engineering Documents (https://global.ihs.com/). Electronic copies are available in the United States from the American National Standards Institute (https://www.ansi.org/)</p>
               </note>
@@ -953,12 +953,12 @@ RSpec.describe Metanorma::Ieee do
            <bibitem id="_" type="standard" anchor="ref1">
              <docidentifier type="ISO" primary="true">ISO/IEC 27001</docidentifier>
              <docidentifier type="iso-reference">ISO/IEC 27001(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso-iec:27001:stage-60.60</docidentifier>
+             <docidentifier type="URN">urn:iso:std:iso-iec:27001</docidentifier>
            </bibitem>
            <bibitem id="_" type="standard" anchor="ref2">
              <docidentifier type="ISO" primary="true">ISO 10642</docidentifier>
              <docidentifier type="iso-reference">ISO 10642(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso:10642:stage-60.60</docidentifier>
+             <docidentifier type="URN">urn:iso:std:iso:10642</docidentifier>
              <note type="Availability">
                <p id="_">ISO publications are available from the International Organization for Standardization (https://www.iso.org/) and the American National Standards Institute (https://www.ansi.org/).</p>
              </note>
@@ -966,7 +966,7 @@ RSpec.describe Metanorma::Ieee do
            <bibitem id="_" type="standard" anchor="ref22">
              <docidentifier type="ISO" primary="true">ISO 639</docidentifier>
              <docidentifier type="iso-reference">ISO 639(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso:639:stage-60.60</docidentifier>
+             <docidentifier type="URN">urn:iso:std:iso:639</docidentifier>
            </bibitem>
            <bibitem id="_" type="standard" anchor="ref25">
              <docidentifier type="ITU" primary="true">ITU-R P.838-3</docidentifier>

--- a/spec/relatondb/cache/etsi/etsi_gs_nfv_002_v1.2.1_2014-12.xml
+++ b/spec/relatondb/cache/etsi/etsi_gs_nfv_002_v1.2.1_2014-12.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn">Network Functions Virtualisation (NFV); Architectural Framework</title>
   <uri type="src">https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=43827</uri>
   <uri type="pdf">https://www.etsi.org/deliver/etsi_gs/NFV/001_099/002/01.02.01_60/gs_NFV002v010201p.pdf</uri>

--- a/spec/relatondb/cache/etsi/etsi_gs_nfv_002_v1.2.1_2014-12.xml
+++ b/spec/relatondb/cache/etsi/etsi_gs_nfv_002_v1.2.1_2014-12.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn">Network Functions Virtualisation (NFV); Architectural Framework</title>
   <uri type="src">https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=43827</uri>
   <uri type="pdf">https://www.etsi.org/deliver/etsi_gs/NFV/001_099/002/01.02.01_60/gs_NFV002v010201p.pdf</uri>

--- a/spec/relatondb/cache/etsi/etsi_gs_zsm_012_v1.1.1_2022-12.xml
+++ b/spec/relatondb/cache/etsi/etsi_gs_zsm_012_v1.1.1_2022-12.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn">Zero-touch network and Service Management (ZSM); Enablers for Artificial Intelligence-based Network and Service Automation</title>
   <uri type="src">https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=62010</uri>
   <uri type="pdf">https://www.etsi.org/deliver/etsi_gs/ZSM/001_099/012/01.01.01_60/gs_ZSM012v010101p.pdf</uri>

--- a/spec/relatondb/cache/etsi/etsi_gs_zsm_012_v1.1.1_2022-12.xml
+++ b/spec/relatondb/cache/etsi/etsi_gs_zsm_012_v1.1.1_2022-12.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn">Zero-touch network and Service Management (ZSM); Enablers for Artificial Intelligence-based Network and Service Automation</title>
   <uri type="src">https://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=62010</uri>
   <uri type="pdf">https://www.etsi.org/deliver/etsi_gs/ZSM/001_099/012/01.01.01_60/gs_ZSM012v010101p.pdf</uri>

--- a/spec/relatondb/cache/iec/iec_60050.xml
+++ b/spec/relatondb/cache/iec/iec_60050.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="title-intro">International Electrotechnical Vocabulary (IEV)</title>
   <title language="en" script="Latn" type="title-main">Index</title>
   <title language="en" script="Latn" type="main">International Electrotechnical Vocabulary (IEV) - Index</title>

--- a/spec/relatondb/cache/iec/iec_60050.xml
+++ b/spec/relatondb/cache/iec/iec_60050.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="title-intro">International Electrotechnical Vocabulary (IEV)</title>
   <title language="en" script="Latn" type="title-main">Index</title>
   <title language="en" script="Latn" type="main">International Electrotechnical Vocabulary (IEV) - Index</title>

--- a/spec/relatondb/cache/iec/iec_61131-3.xml
+++ b/spec/relatondb/cache/iec/iec_61131-3.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="title-main">Programmable controllers – Part 3: Programming languages</title>
   <title language="en" script="Latn" type="main">Programmable controllers – Part 3: Programming languages</title>
   <title language="fr" script="Latn" type="title-main">Automates programmables</title>

--- a/spec/relatondb/cache/iec/iec_61131-3.xml
+++ b/spec/relatondb/cache/iec/iec_61131-3.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="title-main">Programmable controllers – Part 3: Programming languages</title>
   <title language="en" script="Latn" type="main">Programmable controllers – Part 3: Programming languages</title>
   <title language="fr" script="Latn" type="title-main">Automates programmables</title>

--- a/spec/relatondb/cache/itu/itu-r_p.838-3.xml
+++ b/spec/relatondb/cache/itu/itu-r_p.838-3.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="main">Specific attenuation model for rain for use in prediction methods</title>
   <uri type="pdf">https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.838-3-200503-I!!PDF-E.pdf</uri>
   <docidentifier type="ITU" primary="true">ITU-R P.838-3</docidentifier>

--- a/spec/relatondb/cache/itu/itu-r_p.838-3.xml
+++ b/spec/relatondb/cache/itu/itu-r_p.838-3.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="main">Specific attenuation model for rain for use in prediction methods</title>
   <uri type="pdf">https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.838-3-200503-I!!PDF-E.pdf</uri>
   <docidentifier type="ITU" primary="true">ITU-R P.838-3</docidentifier>

--- a/spec/relatondb/cache/itu/itu-r_p.839-4.xml
+++ b/spec/relatondb/cache/itu/itu-r_p.839-4.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="main">Rain height model for prediction methods</title>
   <uri type="pdf">https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.839-4-201309-I!!PDF-E.pdf</uri>
   <docidentifier type="ITU" primary="true">ITU-R P.839-4</docidentifier>

--- a/spec/relatondb/cache/itu/itu-r_p.839-4.xml
+++ b/spec/relatondb/cache/itu/itu-r_p.839-4.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="main">Rain height model for prediction methods</title>
   <uri type="pdf">https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.839-4-201309-I!!PDF-E.pdf</uri>
   <docidentifier type="ITU" primary="true">ITU-R P.839-4</docidentifier>

--- a/spec/relatondb/cache/itu/itu-t_g.984.2.xml
+++ b/spec/relatondb/cache/itu/itu-t_g.984.2.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="title-main">Gigabit-capable Passive Optical Networks (G-PON): Physical Media Dependent (PMD) layer specification</title>
   <title language="en" script="Latn" type="main">Gigabit-capable Passive Optical Networks (G-PON): Physical Media Dependent (PMD) layer specification</title>
   <uri type="src">https://handle.itu.int/11.1002/1000/14000</uri>

--- a/spec/relatondb/cache/itu/itu-t_g.984.2.xml
+++ b/spec/relatondb/cache/itu/itu-t_g.984.2.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="title-main">Gigabit-capable Passive Optical Networks (G-PON): Physical Media Dependent (PMD) layer specification</title>
   <title language="en" script="Latn" type="main">Gigabit-capable Passive Optical Networks (G-PON): Physical Media Dependent (PMD) layer specification</title>
   <uri type="src">https://handle.itu.int/11.1002/1000/14000</uri>

--- a/spec/relatondb/cache/itu/itu-t_k.20.xml
+++ b/spec/relatondb/cache/itu/itu-t_k.20.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn" type="title-main">Resistibility of telecommunication equipment installed in a telecommunication centre to overvoltages and overcurrents</title>
   <title language="en" script="Latn" type="main">Resistibility of telecommunication equipment installed in a telecommunication centre to overvoltages and overcurrents</title>
   <uri type="src">https://handle.itu.int/11.1002/1000/15177</uri>

--- a/spec/relatondb/cache/itu/itu-t_k.20.xml
+++ b/spec/relatondb/cache/itu/itu-t_k.20.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn" type="title-main">Resistibility of telecommunication equipment installed in a telecommunication centre to overvoltages and overcurrents</title>
   <title language="en" script="Latn" type="main">Resistibility of telecommunication equipment installed in a telecommunication centre to overvoltages and overcurrents</title>
   <uri type="src">https://handle.itu.int/11.1002/1000/15177</uri>

--- a/spec/relatondb/cache/w3c/w3c_xml.xml
+++ b/spec/relatondb/cache/w3c/w3c_xml.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-05-26</fetched>
+  <fetched>2026-06-18</fetched>
   <title language="en" script="Latn">Extensible Markup Language (XML) 1.0 (Fifth Edition)</title>
   <uri type="src">https://www.w3.org/TR/xml/</uri>
   <docidentifier type="W3C" primary="true">W3C xml</docidentifier>

--- a/spec/relatondb/cache/w3c/w3c_xml.xml
+++ b/spec/relatondb/cache/w3c/w3c_xml.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.5.6">
-  <fetched>2026-06-18</fetched>
+  <fetched>2026-06-19</fetched>
   <title language="en" script="Latn">Extensible Markup Language (XML) 1.0 (Fifth Edition)</title>
   <uri type="src">https://www.w3.org/TR/xml/</uri>
   <docidentifier type="W3C" primary="true">W3C xml</docidentifier>

--- a/spec/relatondb/cache/w3c/w3c_xptr.notfound
+++ b/spec/relatondb/cache/w3c/w3c_xptr.notfound
@@ -1,1 +1,1 @@
-not_found 2026-05-26
+not_found 2026-06-18

--- a/spec/relatondb/cache/w3c/w3c_xptr.notfound
+++ b/spec/relatondb/cache/w3c/w3c_xptr.notfound
@@ -1,1 +1,1 @@
-not_found 2026-06-18
+not_found 2026-06-19


### PR DESCRIPTION
Refs https://github.com/relaton/relaton-render/issues/77

`relaton-render` 1.3.0 ([relaton/relaton-render#78](https://github.com/relaton/relaton-render/pull/78)) splits the polysemous `at:` and `in:` i18n keys into per-sense sub-keys. This gem's render-config templates updated:

- `labels['at']` → `labels['at_url']` (URL/access-location)
- `labels['in']` paired with `host_creatornames` → `labels['in_document']`
- `labels['in']` paired with `series` → `labels['in_series']`

isodoc gemspec pinned to relaton-render `~> 1.3.0` in [metanorma/isodoc#800](https://github.com/metanorma/isodoc/pull/800). CI will be red until both upstream PRs are merged and relaton-render 1.3.0 reaches rubygems; locally exercise via Gemfile.devel pinning to the two upstream PR branches (`fix/at-in-i18n-disambiguation` in both).
