### PR TITLE
honour taste docstage-valid in stage validation

### DIFF
--- a/lib/metanorma/ieee/validate.rb
+++ b/lib/metanorma/ieee/validate.rb
@@ -36,7 +36,10 @@ module Metanorma
 
       def stage_validate(xmldoc)
         stage = xmldoc&.at("//bibdata/status/stage")&.text
-        %w(draft approved superseded withdrawn).include? stage or
+        # a taste's stage repertoire (:docstage-valid:) supersedes the
+        # flavour's own
+        stages = @docstage_valid || %w(draft approved superseded withdrawn)
+        stages.include? stage or
           @log.add("IEEE_7", nil, params: [stage])
       end
 

--- a/spec/metanorma/validate_spec.rb
+++ b/spec/metanorma/validate_spec.rb
@@ -48,6 +48,34 @@ RSpec.describe Metanorma::Ieee, type: :validation do
     expect(errors).to include("pizza is not a recognised stage")
   end
 
+  it "Validates docstage against docstage-valid when a taste supplies it" do
+    errors = convert_and_capture_errors(<<~INPUT)
+      = Document title
+      Author
+      :docfile: test.adoc
+      :nodoc:
+      :no-isobib:
+      :docstage: pizza
+      :docstage-valid: pizza, calzone
+
+      text
+    INPUT
+    expect(errors).not_to include("pizza is not a recognised stage")
+
+    errors = convert_and_capture_errors(<<~INPUT)
+      = Document title
+      Author
+      :docfile: test.adoc
+      :nodoc:
+      :no-isobib:
+      :docstage: draft
+      :docstage-valid: pizza, calzone
+
+      text
+    INPUT
+    expect(errors).to include("draft is not a recognised stage")
+  end
+
   context "Capitalisation validation" do
     let(:uncapitalised_title) do
       convert_and_capture_errors(<<~INPUT)


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Part of the taste stage-repertoire takeover: tastes validate input stages against their own repertoire and advertise the mapped base stages to the flavour as `:docstage-valid:`, which supersedes the flavour's recognised-stage list. Companion PRs in metanorma-standoc, metanorma-generic, metanorma-taste, isodoc, metanorma-ieee, metanorma-nist, metanorma-iso; release metanorma-standoc first, metanorma-taste last. Full narrative on the ticket.

🤖
