### PR TITLE
render generator errormsg in related in boldface

### DIFF
--- a/lib/isodoc/ieee/presentation_concepts.rb
+++ b/lib/isodoc/ieee/presentation_concepts.rb
@@ -30,6 +30,9 @@ module IsoDoc
       def related_term(term)
         r = term.at(ns("./fmt-related"))
         r.xpath(ns(".//xref | .//eref | .//termref")).each(&:remove)
+        # generator-emitted term-resolution failure reports
+        # (metanorma-model-iso#144) render in boldface
+        r.xpath(ns(".//errormsg")).each { |e| e.name = "strong" }
         coll = sort_related(r.xpath(ns("./semx")))
         r.children = term_related_collapse(coll)
       end

--- a/lib/isodoc/ieee/presentation_terms.rb
+++ b/lib/isodoc/ieee/presentation_terms.rb
@@ -114,7 +114,8 @@ module IsoDoc
           orig = p.at(ns(".//semx[@element = 'related']"))
           p.add_first_child "<em>#{@i18n.relatedterms[orig['type']]}:</em> "
           p.xpath(ns(".//semx[@element = 'related']")).each do |r|
-            r.at(ns("./fmt-preferred")) or
+            # ./strong: flattened errormsg, already carries the failure report
+            r.at(ns("./fmt-preferred | ./strong")) or
               r.add_first_child "**RELATED TERM NOT FOUND**"
           end
         end

--- a/spec/isodoc/terms_spec.rb
+++ b/spec/isodoc/terms_spec.rb
@@ -1934,6 +1934,35 @@ RSpec.describe IsoDoc do
       .to be_xml_equivalent_to output
   end
 
+  it "renders generator errormsg in related in boldface" do
+    input = <<~INPUT
+      <iso-standard xmlns='http://riboseinc.com/isoxml'>
+         <sections>
+           <terms id='A' obligation='normative'>
+             <title>Terms and definitions</title>
+             <term id='C'>
+             <preferred>Base Term</preferred>
+             <definition>Definition</definition>
+             <related type='contrast'><errormsg>term <tt>blah</tt> not resolved via ID <tt>blah</tt></errormsg></related>
+             </term>
+           </terms>
+         </sections>
+       </iso-standard>
+    INPUT
+    pres_output = IsoDoc::Ieee::PresentationXMLConvert
+      .new(presxml_options)
+      .convert("test", input, true)
+    xml = Nokogiri::XML(pres_output)
+    xml.remove_namespaces!
+    fmt = xml.at("//fmt-definition//semx[@element = 'related']/strong[tt]")
+    expect(fmt).not_to be_nil
+    expect(fmt.text).to include "not resolved via ID"
+    expect(xml.at("//fmt-definition").text)
+      .not_to include "RELATED TERM NOT FOUND"
+    expect(xml.at("//term/related/errormsg")).not_to be_nil
+    expect(xml.at("//fmt-definition//errormsg")).to be_nil
+  end
+
   it "processes termnotes with license information" do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/pull/1229

Downstream of metanorma-model-iso#144: `related_term` flattens `errormsg` to `strong` so the failure report survives term collapse (it previously leaked raw and additionally got the `**RELATED TERM NOT FOUND**` prefix). Spec added.

🤖
